### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPluginWithGradle(useContainerAgent: true)

--- a/src/test/java/org/jenkins/plugins/cbt_jenkins/DummyTest.java
+++ b/src/test/java/org/jenkins/plugins/cbt_jenkins/DummyTest.java
@@ -1,0 +1,14 @@
+package org.jenkins.plugins.cbt_jenkins;
+
+import org.junit.Test;
+
+public class DummyTest {
+
+    @Test
+    public void anything() {
+        /*
+         * Intentionally blank. We just want a test that runs with JUnit so that buildPluginWithGradle() works
+         * in the Jenkinsfile.
+         */
+    }
+}


### PR DESCRIPTION
The buildPlugin syntax is reserved for plugins using maven, and deprecated for plugins using gradle to build.
The change proposed updates the syntax to use the proper buildPluginWithGradle build step.

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.